### PR TITLE
Revert Bump micromatch and gulp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dotenv": "^6.0.0",
         "express": "^4.19.2",
         "express-session": "^1.17.2",
-        "gulp": "^5.0.0",
+        "gulp": "^4.0.2",
         "gulp-babel": "^8.0.0",
         "gulp-clean": "^0.4.0",
         "gulp-clean-css": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dotenv": "^6.0.0",
     "express": "^4.19.2",
     "express-session": "^1.17.2",
-    "gulp": "^5.0.0",
+    "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-clean": "^0.4.0",
     "gulp-clean-css": "^4.3.0",


### PR DESCRIPTION
Revert back to gulp 4.0.2 instead of 5.0.0 to make sure images display

## Description

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
